### PR TITLE
Fix formatting

### DIFF
--- a/src/__tests/endpoints.test.ts
+++ b/src/__tests/endpoints.test.ts
@@ -14,8 +14,8 @@ describe('parseEnvVariables', () => {
             process.env = {
                 ...process.env,
                 'CODEFLY__ENDPOINT__BACKEND__API__NAME__REST': encodedURL,
-                'CODEFLY__REST_ROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__GREETER___GET': 'public',
-                'CODEFLY__REST_ROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___POST': 'application',
+                'CODEFLY__RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__GREETER___GET': 'public',
+                'CODEFLY__RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___POST': 'application',
             };
 
             endpoints = getEndpoints();
@@ -38,4 +38,3 @@ describe('parseEnvVariables', () => {
         });
     })
 });
-

--- a/src/__tests/internal.test.ts
+++ b/src/__tests/internal.test.ts
@@ -20,7 +20,7 @@ describe('codefly getEndpointUrl', () => {
     it('should return the correct address for a given route', () => {
         // Mock environment variables
         process.env.CODEFLY__ENDPOINT__BACKEND__API__NAME__REST = encodedURL;
-        process.env.CODEFLY_RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___GET = 'public';
+        process.env.CODEFLY__RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___GET = 'public';
 
         // Dynamically import codefly internal to ensure it uses the updated process.env
         const { getEndpointUrl } = require('../internal');
@@ -33,7 +33,7 @@ describe('codefly getEndpointUrl', () => {
     it('should return null if the method is not available', () => {
         // Mock environment variables
         process.env.CODEFLY__ENDPOINT__BACKEND__API__NAME__REST = encodedURL;
-        process.env.CODEFLY_RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___GET = 'public';
+        process.env.CODEFLY__RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___GET = 'public';
 
         // Dynamically import codefly internal to ensure it uses the updated process.env
         const { getEndpointUrl } = require('../internal');
@@ -47,7 +47,7 @@ describe('codefly getEndpointUrl', () => {
     it('should return null if the route is not available', () => {
         // Mock environment variables
         process.env.CODEFLY__ENDPOINT__BACKEND__API__NAME__REST = encodedURL;
-        process.env.CODEFLY_RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___GET = 'public';
+        process.env.CODEFLY__RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___GET = 'public';
 
         // Dynamically import codefly internal to ensure it uses the updated process.env
         const { getEndpointUrl } = require('../internal');
@@ -60,7 +60,7 @@ describe('codefly getEndpointUrl', () => {
     it('should return null if the service is not available', () => {
         // Mock environment variables
         process.env.CODEFLY__ENDPOINT__BACKEND__API__NAME__REST = encodedURL;
-        process.env.CODEFLY_RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___GET = 'public';
+        process.env.CODEFLY__RESTROUTE__BACKEND__API__NAME__REST___BACKEND__SERVER__VERSION___GET = 'public';
 
         // Dynamically import codefly internal to ensure it uses the updated process.env
         const { getEndpointUrl } = require('../internal');

--- a/src/__tests/routing.test.ts
+++ b/src/__tests/routing.test.ts
@@ -34,15 +34,15 @@ describe('routing', () => {
             const endpoints = [
                 {
                     service: 'counter-go-grpc-nextjs-postgres/api',
-                    addresses: [],
+                    address: 'http://localhost:8085',
                     routes: [],
                     applicationName: 'COUNTER-GO-GRPC-NEXTJS-POSTGRES',
                     serviceName: 'API'
                   }
             ]
             
-            routing[method]("test-service", "/route/to", endpoints);
-            expect(spy).toHaveBeenCalledWith(method, "test-service", "/route/to", endpoints);
+            routing[method]("test-app/test-service", "/route/to", endpoints);
+            expect(spy).toHaveBeenCalledWith(method, "test-app/test-service", "/route/to", endpoints);
 
             spy.mockRestore();
         });

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -16,7 +16,8 @@ function parseEndpointsFromEnv() {
     const endpoints: { [key: string]: ServiceEndpoint } = {};
 
     Object.keys(process.env).forEach((key) => {
-        const endpointMatch = key.match(/^CODEFLY_ENDPOINT__(.+)__(.+)___REST$/);
+        // CODEFLY__ENDPOINT__BACKEND__API__NAME__REST
+        const endpointMatch = key.match(/^CODEFLY__ENDPOINT__(.+)__(.+)__NAME__REST$/);
 
         if (endpointMatch) {
             const [, applicationName, serviceName] = endpointMatch;
@@ -38,7 +39,7 @@ function parseEndpointsFromEnv() {
 
 function parseRoutes(endpoints: { [key: string]: ServiceEndpoint }) {
     Object.keys(process.env).forEach((key) => {
-        const routeMatch = key.match(/^CODEFLY__REST_ROUTE__(.+)__(.+)__(.*)__REST___(.+)___(.*)$/);
+        const routeMatch = key.match(/^CODEFLY__RESTROUTE__(.+)__(.+)__(.*)__REST___(.+)___(.*)$/);
         if (routeMatch) {
             const [, applicationName, serviceName, endpointName, rest, method] = routeMatch;
             const addressKey = `${applicationName.toUpperCase()}_${serviceName.toUpperCase()}`;

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -27,8 +27,6 @@ export function getEndpointUrl(method: Method, service: string, path: string, se
 }
 
 function getAddressFromServiceEndpoint(serviceEndpoint: ServiceEndpoint, path: string): string | null {
-    // There could be multiple addresses for a service endpoint ATM. 
     // codefly should be able to send a single url for a service endpoint
-    // right now we return the first address of the service endpoint.
-    return serviceEndpoint.addresses[0] ? `${serviceEndpoint.addresses[0]}${path}` : null;
+    return serviceEndpoint.address ? `${serviceEndpoint.address}${path}` : null;
 }


### PR DESCRIPTION
- `REST_ROUTE` -> `RESTROUTE`
- `CODEFLY_RESTROUTE` -> `CODEFLY__RESTROUTE`

- change the regex to map env vars
- change the getAddress to use the single address